### PR TITLE
Build cylinder mesh dimensions

### DIFF
--- a/pyCoilGen/__init__.py
+++ b/pyCoilGen/__init__.py
@@ -1,3 +1,3 @@
 """Magnetic Field Coil Generator for Python."""
 # Semantic Versioning according to https://semver.org/spec/v2.0.0.html
-__version__ = "0.0.10"
+__version__ = "0.0.11"

--- a/pyCoilGen/sub_functions/build_cylinder_mesh.py
+++ b/pyCoilGen/sub_functions/build_cylinder_mesh.py
@@ -42,8 +42,7 @@ def build_cylinder_mesh(
     x_positions = x_positions[:-1]  # Remove repetition at the end
     y_positions = y_positions[:-1]  # Remove repetition at the end
     z_positions = np.linspace(-cylinder_height / 2, cylinder_height / 2,
-                              num_longitudinal_divisions+2)
-    z_positions = z_positions[:-1]  # Remove repetition at the end
+                              num_longitudinal_divisions+1)
 
     # Create the mesh vertices
     vertices_x = np.tile(x_positions, num_longitudinal_divisions+1)

--- a/tests/test_build_cylinder_mesh.py
+++ b/tests/test_build_cylinder_mesh.py
@@ -30,11 +30,9 @@ def test_build_cylinder_mesh_basic():
     assert np.max(mesh.vertices[:, 1]) == cylinder_radius
 
     # Min z is -height/2
-    assert np.min(mesh.vertices[:, 2]) == -(num_longitudinal_divisions /
-                                            (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.min(mesh.vertices[:, 2]) == -cylinder_height/2.0
     # Max z is +height/2
-    assert np.max(mesh.vertices[:, 2]) == (num_longitudinal_divisions /
-                                           (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.max(mesh.vertices[:, 2]) == cylinder_height/2.0
 
     # Test shape
     assert mesh.vertices.shape == ((num_circular_divisions)*(num_longitudinal_divisions+1), 3)
@@ -66,11 +64,9 @@ def test_build_cylinder_mesh_rotate_Z():
     assert np.max(mesh.vertices[:, 1]) == cylinder_radius
 
     # Min z is -height/2
-    assert np.min(mesh.vertices[:, 2]) == -(num_longitudinal_divisions /
-                                            (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.min(mesh.vertices[:, 2]) == -cylinder_height/2.0
     # Max z is +height/2
-    assert np.max(mesh.vertices[:, 2]) == (num_longitudinal_divisions /
-                                           (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.max(mesh.vertices[:, 2]) == cylinder_height/2.0
 
     rotation_angle = np.pi/4
     mesh = build_cylinder_mesh(cylinder_height, cylinder_radius,
@@ -89,11 +85,9 @@ def test_build_cylinder_mesh_rotate_Z():
     assert np.max(mesh.vertices[:, 1]) == cylinder_radius * np.cos(rotation_angle)
 
     # Min z is -height/2
-    assert np.min(mesh.vertices[:, 2]) == -(num_longitudinal_divisions /
-                                            (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.min(mesh.vertices[:, 2]) == -cylinder_height/2.0
     # Max z is +height/2
-    assert np.max(mesh.vertices[:, 2]) == (num_longitudinal_divisions /
-                                           (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.max(mesh.vertices[:, 2]) == cylinder_height/2.0
 
     cylinder_height = 0.25
     cylinder_radius = 0.4
@@ -120,11 +114,9 @@ def test_build_cylinder_mesh_rotate_Z():
     assert np.max(mesh.vertices[:, 1]) == cylinder_radius
 
     # Min z is -height/2
-    assert np.min(mesh.vertices[:, 2]) == -(num_longitudinal_divisions /
-                                            (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.min(mesh.vertices[:, 2]) == -cylinder_height/2.0
     # Max z is +height/2
-    assert np.max(mesh.vertices[:, 2]) == (num_longitudinal_divisions /
-                                           (num_longitudinal_divisions+1) * cylinder_height)/2
+    assert np.max(mesh.vertices[:, 2]) == cylinder_height/2.0
 
 
 def test_build_cylinder_mesh_rotate_Y():
@@ -143,11 +135,9 @@ def test_build_cylinder_mesh_rotate_Y():
 
     # Mesh rotated Z onto X
     # Min x is -radius
-    assert np.min(mesh.vertices[:, 0]) == approx(-(num_longitudinal_divisions /
-                                                   (num_longitudinal_divisions+1) * cylinder_height)/2)
+    assert np.min(mesh.vertices[:, 0]) == approx(-cylinder_height/2.0)
     # Max x is +radius
-    assert np.max(mesh.vertices[:, 0]) == approx(+(num_longitudinal_divisions /
-                                                   (num_longitudinal_divisions+1) * cylinder_height)/2)
+    assert np.max(mesh.vertices[:, 0]) == approx(+cylinder_height/2.0)
 
     # Min y is -radius
     assert np.min(mesh.vertices[:, 1]) == -cylinder_radius
@@ -181,48 +171,11 @@ def test_build_cylinder_mesh_rotate_X():
     assert np.max(mesh.vertices[:, 0]) == cylinder_radius
 
     # Min y is -radius
-    assert np.min(mesh.vertices[:, 1]) == approx(-(num_longitudinal_divisions /
-                                                   (num_longitudinal_divisions+1) * cylinder_height)/2)
+    assert np.min(mesh.vertices[:, 1]) == approx(-cylinder_height/2.0)
     # Max y is +radius
-    assert np.max(mesh.vertices[:, 1]) == approx(+(num_longitudinal_divisions /
-                                                   (num_longitudinal_divisions+1) * cylinder_height)/2)
+    assert np.max(mesh.vertices[:, 1]) == approx(+cylinder_height/2.0)
 
     # Min z is -height/2
     assert np.min(mesh.vertices[:, 2]) == -cylinder_radius
     # Max z is +height/2
     assert np.max(mesh.vertices[:, 2]) == +cylinder_radius
-
-
-def test_compare_matlab():
-    matlab_cylinder_vertices = [[0, 0.4, -0.0938],
-                                [0.4, 0, -0.0938],
-                                [0, -0.4, -0.0938],
-                                [-0.4, 0, -0.0938],
-                                [0, 0.4, -0.0312],
-                                [0.4, 0, -0.0312],
-                                [0, -0.4, -0.0312],
-                                [-0.4, 0, -0.0312],
-                                [0, 0.4, 0.0312],
-                                [0.4, 0, 0.0312],
-                                [0, -0.4, 0.0312],
-                                [-0.4, 0, 0.0312],
-                                [0, 0.4, 0.0938],
-                                [0.4, 0, 0.0938],
-                                [0, -0.4, 0.0938],
-                                [-0.4, 0, 0.0938]]
-
-    cylinder_height = 0.25
-    cylinder_radius = 0.4
-    num_circular_divisions = 4
-    num_longitudinal_divisions = 3
-    rotation_vector_x = 0
-    rotation_vector_y = 0
-    rotation_vector_z = 1.0
-    rotation_angle = 0
-
-    mesh = build_cylinder_mesh(cylinder_height, cylinder_radius,
-                               num_circular_divisions, num_longitudinal_divisions,
-                               rotation_vector_x, rotation_vector_y, rotation_vector_z, rotation_angle)
-    vertices = mesh.vertices.tolist()
-    for index in range(len(vertices)):
-        assert all(np.abs(x - y) < 0.001 for x, y in zip(vertices[index], matlab_cylinder_vertices[index]))


### PR DESCRIPTION
The original MATLAB code generates meshes that are slightly smaller than the input dimensions.
This PR changes the Python behaviour to return a mesh which has dimensions that exactly match the `cylinder_height` and `cylinder_radius` as expected.