### PR TITLE
fix: Fix runtime error due to numpy deprecation.

### DIFF
--- a/pyCoilGen/sub_functions/calc_contours_by_triangular_potential_cuts.py
+++ b/pyCoilGen/sub_functions/calc_contours_by_triangular_potential_cuts.py
@@ -2,10 +2,10 @@ import numpy as np
 from typing import List
 from dataclasses import dataclass
 import trimesh  # For face and vertex adjacency
+import warnings
 
 # Logging
 import logging
-import warnings
 
 # Local imports
 from .data_structures import CoilPart

--- a/pyCoilGen/sub_functions/calc_contours_by_triangular_potential_cuts.py
+++ b/pyCoilGen/sub_functions/calc_contours_by_triangular_potential_cuts.py
@@ -5,6 +5,7 @@ import trimesh  # For face and vertex adjacency
 
 # Logging
 import logging
+import warnings
 
 # Local imports
 from .data_structures import CoilPart
@@ -100,7 +101,7 @@ def calc_contours_by_triangular_potential_cuts(coil_parts: List[CoilPart]):
         edge_potential_span = edge_node_potentials[:, 1] - edge_node_potentials[:, 0]
         edge_potential_span = np.tile(edge_potential_span[:, np.newaxis], (1, num_potentials))
 
-        np.warnings.filterwarnings('ignore')
+        warnings.filterwarnings('ignore')
 
         pot_dist_to_step = rep_contour_level_list - np.tile(edge_node_potentials[:, 0][:, np.newaxis],
                                                             (1, num_potentials))
@@ -118,7 +119,7 @@ def calc_contours_by_triangular_potential_cuts(coil_parts: List[CoilPart]):
         v_cut_point = potential_cut_criteria * (
             first_edge_node_v + v_component_edge_vectors * cut_point_distance_to_edge_node_1 / edge_lengths)
 
-        np.warnings.filterwarnings('default')
+        warnings.filterwarnings('default')
 
         # Create cell by sorting the cut points to the corresponding potential levels
         potential_sorted_cut_points = np.zeros((num_potentials), dtype=object)  # 20 x M x 3

--- a/pyCoilGen/sub_functions/generate_cylindrical_pcb_print.py
+++ b/pyCoilGen/sub_functions/generate_cylindrical_pcb_print.py
@@ -1,5 +1,6 @@
 import numpy as np
 from typing import List
+import warnings
 
 from .data_structures import CoilPart, PCBTrack, PCBLayer, GroupLayout, PCBPart, Polygon
 from .calc_3d_rotation_matrix_by_vector import calc_3d_rotation_matrix_by_vector
@@ -217,7 +218,7 @@ def generate_cylindrical_pcb_print(coil_parts: List[CoilPart], input_args):
                             )
                             pcb_parts[point_ind] = pcb_part
 
-                        np.warnings.filterwarnings('ignore')
+                        warnings.filterwarnings('ignore')
 
                         for wrap_ind in range(len(pcb_parts)):
                             intersection_cut = find_segment_intersections(pcb_parts[wrap_ind].uv, cut_rectangle)
@@ -240,7 +241,7 @@ def generate_cylindrical_pcb_print(coil_parts: List[CoilPart], input_args):
                                         wire_part_points[:, cut_segment_ind+1:-1]
                                     ))
 
-                        np.warnings.filterwarnings('default')
+                        warnings.filterwarnings('default')
 
                         for wrap_ind in range(1, len(pcb_parts)):
                             if pcb_parts[wrap_ind - 1].uv[0, -1] > 0:


### PR DESCRIPTION
Numpy removed access to deprecated "numpy.warnings". Now uses "import warnings" to access Python warnings.

Fix: closes https://github.com/kev-m/pyCoilGen/pull/68